### PR TITLE
Avoid a deprecation warning due to the new intimate router (_router) API

### DIFF
--- a/addon/mixins/body-class.js
+++ b/addon/mixins/body-class.js
@@ -8,10 +8,11 @@ export default Mixin.create({
     loading(/* transition, route */) {
       const document = getOwner(this).lookup('service:-document');
       const body = document.body;
+      let router = this._router || this.router;
 
       addClass(body, 'loading');
 
-      this.router.on('didTransition', function() {
+      router.on('didTransition', function() {
         removeClass(body, 'loading');
       });
 
@@ -21,10 +22,11 @@ export default Mixin.create({
     error: function(/* error, transition */) {
       const document = getOwner(this).lookup('service:-document');
       const body = document.body;
+      let router = this._router || this.router;
 
       addClass(body, 'error');
 
-      this.router.on('didTransition', function() {
+      router.on('didTransition', function() {
         removeClass(body, 'error');
       });
 


### PR DESCRIPTION
This deprecation warning was annoying me. I'm not sure if this is the right way to fix the problem, but all tests are passing.